### PR TITLE
[추가][수정] 달리기 애니메이션 추가, 무적 버그 수정

### DIFF
--- a/src/main/java/Main/View.java
+++ b/src/main/java/Main/View.java
@@ -5,6 +5,8 @@ import java.util.Timer;
 import java.util.TimerTask;
 import Util.InGame;
 
+import javax.swing.*;
+
 public class View extends Canvas
 {
     private Graphics bufferGraphics;

--- a/src/main/java/Object/Character/Beagle.java
+++ b/src/main/java/Object/Character/Beagle.java
@@ -16,8 +16,16 @@ public class Beagle extends Chr
 
         try
         {
-            image = ImageIO.read(new File("src/main/resources/chr/Bi/basic.png"));
-            image = image.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+            image_basic = ImageIO.read(new File("src/main/resources/chr/Bi/basic.png"));
+            image_basic = image_basic.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+
+            image_run = ImageIO.read(new File("src/main/resources/chr/Bi/run.png"));
+            image_run = image_run.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+
+            image_die = ImageIO.read(new File("src/main/resources/chr/Bi/dead.png"));
+            image_die = image_die.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+
+            image = image_basic;
         }
         catch (IOException e)
         {

--- a/src/main/java/Object/Character/Chr.java
+++ b/src/main/java/Object/Character/Chr.java
@@ -3,6 +3,7 @@ package Object.Character;
 import Main.MainFrame;
 import Main.View;
 import Object.GameObject;
+import Util.Time;
 
 import java.awt.*;
 import java.awt.event.KeyEvent;
@@ -13,15 +14,21 @@ public class Chr extends GameObject implements KeyListener
     public int maxLife;
     public int nowLife;
 
-    private double jumpingDelay;
-    private double landingDelay;
-    private double runAnimDelay;
-
     private boolean jumping;
     private boolean landing;
+    private double jumpingDelay;
+    private double landingDelay;
+    private Time movingTime;
 
-    protected boolean invincible;
-    protected double invincibleTime;
+    private double runAnimDelay;
+    private double hitAnimDelay;
+    private Time runAniTime;
+    private Time hitAniTime;
+
+    private boolean invincible;
+    private boolean hitAnimSwitch;
+    private double invincibleDelay;
+    private Time invincibleTime;
 
     protected Image image_basic;
     protected Image image_run;
@@ -44,24 +51,34 @@ public class Chr extends GameObject implements KeyListener
         maxLife = 3;
         nowLife = 3;
 
-        jumpingDelay = 0.020;
-        landingDelay = 0.020;
-        runAnimDelay = 0.07;
-
         jumping = false;
         landing = false;
+        jumpingDelay = 0.020;
+        landingDelay = 0.020;
+        movingTime = new Time();
+
+        runAnimDelay = 0.07;
+        hitAnimDelay = 0.07;
+        runAniTime = new Time();
+        hitAniTime = new Time();
 
         invincible = false;
-        invincibleTime = 7;
+        hitAnimSwitch = false;
+        invincibleTime = new Time();
     }
 
     @Override
     public void draw (Graphics g, View view)
     {
         super.draw(g, view);
+
         Jump();
         ReleaseInvincible();
+
         RunningAnimation();
+        HitAnimation();
+
+        Die();
     }
 
     @Override
@@ -96,7 +113,7 @@ public class Chr extends GameObject implements KeyListener
         if (jumping)
         {
             image = image_basic;
-            if (time.timeCtrl(jumpingDelay))
+            if (movingTime.timeCtrl(jumpingDelay))
                 pos_y -= gap;
             if (pos_y < MainFrame.ground_y - MainFrame.jumpLimit)
             {
@@ -106,7 +123,7 @@ public class Chr extends GameObject implements KeyListener
         }
         else if (landing)
         {
-            if (time.timeCtrl(landingDelay))
+            if (movingTime.timeCtrl(landingDelay))
             {
                 pos_y += gap;
             }
@@ -125,25 +142,29 @@ public class Chr extends GameObject implements KeyListener
 
     public void setInvincible(double invincibleTime)
     {
-        this.invincible = true;
-        this.invincibleTime = invincibleTime;
+        invincible = true;
+        //time.timeCtrl(invincibleTime);
+        invincibleDelay = invincibleTime;
     }
 
     protected void ReleaseInvincible()
     {
         if (invincible)
         {
-            if (time.timeCtrl(invincibleTime))
+            if (invincibleTime.timeCtrl(invincibleDelay))
             {
-                this.invincible = false;
-                System.out.println("invincible release-chr state: " + this.invincible);
+                invincible = false;
+                System.out.println("invincible release-chr state: " + invincible);
+
+                setHitAnimSwitch(false);
+                image = image_basic;
             }
         }
     }
 
     private void RunningAnimation()
     {
-        if (time.timeCtrl(runAnimDelay))
+        if (runAniTime.timeCtrl(runAnimDelay))
         {
             if (image.equals(image_basic))
             {
@@ -153,6 +174,32 @@ public class Chr extends GameObject implements KeyListener
             {
                 image = image_basic;
             }
+        }
+    }
+
+    private void HitAnimation()
+    {
+        if (hitAnimSwitch)
+        {
+            image = image_die;
+            if (hitAniTime.timeCtrl(hitAnimDelay))
+            {
+                System.out.println("blink");
+            }
+        }
+    }
+
+    public void setHitAnimSwitch(boolean val)
+    {
+        hitAnimSwitch = val;
+    }
+
+    private void Die ()
+    {
+        if (nowLife == 0)
+        {
+            System.out.println("Game Over");
+            image = image_die;
         }
     }
 }

--- a/src/main/java/Object/Character/Chr.java
+++ b/src/main/java/Object/Character/Chr.java
@@ -15,6 +15,7 @@ public class Chr extends GameObject implements KeyListener
 
     private double jumpingDelay;
     private double landingDelay;
+    private double runAnimDelay;
 
     private boolean jumping;
     private boolean landing;
@@ -22,6 +23,7 @@ public class Chr extends GameObject implements KeyListener
     protected boolean invincible;
     protected double invincibleTime;
 
+    protected Image image_basic;
     protected Image image_run;
     protected Image image_die;
 
@@ -44,6 +46,7 @@ public class Chr extends GameObject implements KeyListener
 
         jumpingDelay = 0.020;
         landingDelay = 0.020;
+        runAnimDelay = 0.07;
 
         jumping = false;
         landing = false;
@@ -58,6 +61,7 @@ public class Chr extends GameObject implements KeyListener
         super.draw(g, view);
         Jump();
         ReleaseInvincible();
+        RunningAnimation();
     }
 
     @Override
@@ -91,6 +95,7 @@ public class Chr extends GameObject implements KeyListener
      {
         if (jumping)
         {
+            image = image_basic;
             if (time.timeCtrl(jumpingDelay))
                 pos_y -= gap;
             if (pos_y < MainFrame.ground_y - MainFrame.jumpLimit)
@@ -132,6 +137,21 @@ public class Chr extends GameObject implements KeyListener
             {
                 this.invincible = false;
                 System.out.println("invincible release-chr state: " + this.invincible);
+            }
+        }
+    }
+
+    private void RunningAnimation()
+    {
+        if (time.timeCtrl(runAnimDelay))
+        {
+            if (image.equals(image_basic))
+            {
+                image = image_run;
+            }
+            else if (image.equals(image_run))
+            {
+                image = image_basic;
             }
         }
     }

--- a/src/main/java/Object/Character/Chr.java
+++ b/src/main/java/Object/Character/Chr.java
@@ -8,6 +8,8 @@ import Util.Time;
 import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.awt.image.BufferedImage;
+import java.awt.image.RescaleOp;
 
 public class Chr extends GameObject implements KeyListener
 {
@@ -143,7 +145,6 @@ public class Chr extends GameObject implements KeyListener
     public void setInvincible(double invincibleTime)
     {
         invincible = true;
-        //time.timeCtrl(invincibleTime);
         invincibleDelay = invincibleTime;
     }
 
@@ -181,10 +182,9 @@ public class Chr extends GameObject implements KeyListener
     {
         if (hitAnimSwitch)
         {
-            image = image_die;
             if (hitAniTime.timeCtrl(hitAnimDelay))
             {
-                System.out.println("blink");
+                
             }
         }
     }
@@ -192,6 +192,8 @@ public class Chr extends GameObject implements KeyListener
     public void setHitAnimSwitch(boolean val)
     {
         hitAnimSwitch = val;
+        if (hitAnimSwitch)
+            image = image_die;
     }
 
     private void Die ()

--- a/src/main/java/Object/Character/Maltese.java
+++ b/src/main/java/Object/Character/Maltese.java
@@ -15,8 +15,16 @@ public class Maltese extends Chr
 
         try
         {
-            image = ImageIO.read(new File("src/main/resources/chr/Mal/basic.png"));
-            image = image.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+            image_basic = ImageIO.read(new File("src/main/resources/chr/Mal/basic.png"));
+            image_basic = image_basic.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+
+            image_run = ImageIO.read(new File("src/main/resources/chr/Mal/run.png"));
+            image_run = image_run.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+
+            image_die = ImageIO.read(new File("src/main/resources/chr/Mal/dead.png"));
+            image_die = image_die.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+
+            image = image_basic;
         }
         catch (IOException e)
         {

--- a/src/main/java/Object/Character/Pomeranian.java
+++ b/src/main/java/Object/Character/Pomeranian.java
@@ -15,8 +15,16 @@ public class Pomeranian extends Chr
 
         try
         {
-            image = ImageIO.read(new File("src/main/resources/chr/Po/basic.png"));
-            image = image.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+            image_basic = ImageIO.read(new File("src/main/resources/chr/Po/basic.png"));
+            image_basic = image_basic.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+
+            image_run = ImageIO.read(new File("src/main/resources/chr/Po/run.png"));
+            image_run = image_run.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+
+            image_die = ImageIO.read(new File("src/main/resources/chr/Po/dead.png"));
+            image_die = image_die.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+
+            image = image_basic;
         }
         catch (IOException e)
         {

--- a/src/main/java/Object/GameObject.java
+++ b/src/main/java/Object/GameObject.java
@@ -24,7 +24,6 @@ public class GameObject
 
     public Image image;
     public View view;
-    public Time time;
 
     public GameObject (View view)
     {
@@ -34,7 +33,6 @@ public class GameObject
         gameSpeed = 0.010;
 
         this.view = view;
-        time = new Time();
     }
 
     public void draw(Graphics g, View view)

--- a/src/main/java/Object/MovingObject/Item/DogBone.java
+++ b/src/main/java/Object/MovingObject/Item/DogBone.java
@@ -22,7 +22,7 @@ public class DogBone extends Item
         margin_x = width - 20;
         margin_y = height - 20;
 
-        invincibleTimebyDogBone = 7.5;
+        invincibleTimebyDogBone = 7;
 
         try
         {

--- a/src/main/java/Object/MovingObject/MovingObject.java
+++ b/src/main/java/Object/MovingObject/MovingObject.java
@@ -5,6 +5,8 @@ import Main.MainFrame;
 import Main.View;
 import Object.GameObject;
 import Object.Character.Chr;
+import Util.Time;
+
 import java.util.Random;
 
 public class MovingObject extends GameObject
@@ -12,6 +14,7 @@ public class MovingObject extends GameObject
     protected double movingDelay;
     protected boolean isEnable;
     protected final int[] obj_pos_y = new int[3];    // moving object will appear 3 value of y
+    private Time movingTime;
 
     public MovingObject (View view)
     {
@@ -24,6 +27,8 @@ public class MovingObject extends GameObject
         obj_pos_y[0] = MainFrame.ground_y - MainFrame.jumpLimit;
         obj_pos_y[1] = MainFrame.ground_y - (MainFrame.jumpLimit / 2);  // between obj_pos[0] and obj_pos[2]
         obj_pos_y[2] = MainFrame.ground_y;
+
+        movingTime = new Time();
     }
 
     protected void Move ()
@@ -32,7 +37,7 @@ public class MovingObject extends GameObject
         {
             if (pos_x >= 0)
             {
-                if (time.timeCtrl(movingDelay))
+                if (movingTime.timeCtrl(movingDelay))
                     pos_x -= gap;
             }
             else

--- a/src/main/java/Util/BGScroll.java
+++ b/src/main/java/Util/BGScroll.java
@@ -14,10 +14,11 @@ public class BGScroll extends GameObject
 
     private double drawDelay;
     private int pos_x2;
-
+    private Time drawTime;
     public BGScroll (View view)
     {
         super(view);
+
         try
         {
             image = ImageIO.read(new File("src/main/resources/bg/ingame.png"));
@@ -27,11 +28,16 @@ public class BGScroll extends GameObject
         {
             e.printStackTrace();
         }
+
         gap = 5;
+
         pos_x = 0;
         pos_y = 0;
+
         pos_x2 = image.getWidth(null);
+
         drawDelay = super.gameSpeed;
+        drawTime = new Time();
     }
 
     public void draw (Graphics g, View view)
@@ -43,7 +49,7 @@ public class BGScroll extends GameObject
 
     public void Scroll ()
     {
-        if (time.timeCtrl(drawDelay))
+        if (drawTime.timeCtrl(drawDelay))
         {
             pos_x -= gap;
             pos_x2 -= gap;

--- a/src/main/java/Util/InGame.java
+++ b/src/main/java/Util/InGame.java
@@ -26,7 +26,7 @@ public class InGame
 
     private BGScroll bgScroll;
 
-    private Time time;
+    private Time makingTime;
 
     private Collision obsCollision;
     private Collision itemCollision;
@@ -47,7 +47,7 @@ public class InGame
 
         bgScroll = new BGScroll(view);
 
-        time = new Time();
+        makingTime = new Time();
 
         makingDelay = 1.7;
         invincibleTimeByObs = 7;
@@ -117,10 +117,12 @@ public class InGame
             }
         }
 
-        if (time.timeCtrl(makingDelay))
+        if (makingTime.timeCtrl(makingDelay))
         {
             MakeMovingObject();
         }
+
+        score++;
     }
 
     private void CheckObsCollision (int index)

--- a/src/main/java/Util/InGame.java
+++ b/src/main/java/Util/InGame.java
@@ -50,7 +50,7 @@ public class InGame
         time = new Time();
 
         makingDelay = 1.7;
-        invincibleTimeByObs = 6.5;
+        invincibleTimeByObs = 7;
     }
 
     private void InitObjects(View view)
@@ -59,9 +59,10 @@ public class InGame
         chr = new Pomeranian(view);
         view.addKeyListener(chr);
 
-        obs = new Obstacle[OBSTACLE.values().length * 2];
+        int amountObs = 2;
+        obs = new Obstacle[OBSTACLE.values().length * amountObs];
 
-        for (int i = 0; i < 2; i++)
+        for (int i = 0; i < amountObs; i++)
         {
             // Flying obs pix 1
             obs[0 + i * OBSTACLE.values().length] = new Bird(view);
@@ -79,10 +80,11 @@ public class InGame
             obs[8 + i * OBSTACLE.values().length] = new TrashCan(view);
         }
 
-        item = new Item[ITEM.values().length * 2];
+        int amountItem = 2;
+        item = new Item[ITEM.values().length * amountItem];
 
         // item
-        for (int i = 0; i < 2; i++)
+        for (int i = 0; i < amountItem; i++)
         {
             item[0 + i * ITEM.values().length] = new DogBone(view);
             item[1 + i * ITEM.values().length] = new DogFood(view);
@@ -134,10 +136,7 @@ public class InGame
             chr.setInvincible(invincibleTimeByObs);
             System.out.println("invincible state: " + chr.isInvincible());
 
-            if (chr.nowLife == 0)
-            {
-                System.out.println("Game Over");
-            }
+            chr.setHitAnimSwitch(true);
         }
     }
 


### PR DESCRIPTION
- 캐릭터 달리기 애니메이션 추가(2프레임)
- 무적 판정이 풀리지 않던 버그 수정
  원인: 다른 동작들이 한 time 객체를 공유해 다른 동작의 시간값을 읽어버림
  해결: 동작 별로 하나의 time 객체를 사용함(1동작 1time)  